### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/components/shared/mdx-content.tsx
+++ b/src/components/shared/mdx-content.tsx
@@ -47,7 +47,12 @@ function CustomImage({ ...props }: any) {
     );
 
   // Don't render badges.
-  if (imageSrc.includes('img.shields.io')) return null;
+  try {
+    const url = new URL(imageSrc);
+    if (url.hostname === 'img.shields.io') return null;
+  } catch (e) {
+    // If imageSrc is not a valid URL, continue with the existing logic
+  }
 
   return (
     <div className="my-2 flex justify-center">


### PR DESCRIPTION
Potential fix for [https://github.com/mustafagenc/homepage/security/code-scanning/1](https://github.com/mustafagenc/homepage/security/code-scanning/1)

To fix the problem, we need to parse the URL and check the host component specifically, rather than using a substring check. This ensures that we accurately determine whether the URL belongs to the allowed domain (`img.shields.io`) and is not a part of a malicious URL.

The best way to fix this without changing existing functionality is to use the `URL` constructor to parse the URL and then check the `hostname` property. This approach is more robust and secure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
